### PR TITLE
Fix JwtClaim/JwtHeader model for RFC 7519/OIDC compliance

### DIFF
--- a/src/main/java/net/unit8/bouncr/sign/JsonWebToken.java
+++ b/src/main/java/net/unit8/bouncr/sign/JsonWebToken.java
@@ -244,6 +244,7 @@ public class JsonWebToken extends SystemComponent<JsonWebToken> {
             public void start(JsonWebToken component) {
                 component.mapper = JsonMapper.builder()
                         .enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+                        .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                         .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
                         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                         .build();

--- a/src/main/java/net/unit8/bouncr/sign/JwtClaim.java
+++ b/src/main/java/net/unit8/bouncr/sign/JwtClaim.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,8 +15,8 @@ public class JwtClaim implements Serializable {
     private String iss;
     /** Subject */
     private String sub;
-    /** Audience */
-    private String aud;
+    /** Audience — single string or array per RFC 7519 §4.1.3 */
+    private Object aud;
     /** Expires*/
     private Long exp;
     /** Issued at */
@@ -28,8 +28,8 @@ public class JwtClaim implements Serializable {
     private String nonce;
     /** Authentication Context Class Reference */
     private String acr;
-    /** Authentication Methods Reference */
-    private String amr;
+    /** Authentication Methods Reference — array of strings per OIDC Core §2 */
+    private List<String> amr;
 
     /** Authorized party*/
     private String azp;
@@ -60,8 +60,9 @@ public class JwtClaim implements Serializable {
     @JsonProperty("phone_number_verified")
     private Boolean phoneNumberVerified;
     private ClaimAddress address;
+    /** NumericDate per RFC 7519 §2 */
     @JsonProperty("updated_at")
-    private LocalDateTime updatedAt;
+    private Long updatedAt;
 
     public String getEmail() {
         return email;
@@ -95,11 +96,11 @@ public class JwtClaim implements Serializable {
         this.iss = iss;
     }
 
-    public String getAud() {
+    public Object getAud() {
         return aud;
     }
 
-    public void setAud(String aud) {
+    public void setAud(Object aud) {
         this.aud = aud;
     }
 
@@ -159,11 +160,11 @@ public class JwtClaim implements Serializable {
         this.acr = acr;
     }
 
-    public String getAmr() {
+    public List<String> getAmr() {
         return amr;
     }
 
-    public void setAmr(String amr) {
+    public void setAmr(List<String> amr) {
         this.amr = amr;
     }
 
@@ -287,11 +288,11 @@ public class JwtClaim implements Serializable {
         this.address = address;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Long getUpdatedAt() {
         return updatedAt;
     }
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
+    public void setUpdatedAt(Long updatedAt) {
         this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/net/unit8/bouncr/sign/JwtHeader.java
+++ b/src/main/java/net/unit8/bouncr/sign/JwtHeader.java
@@ -1,4 +1,5 @@
 package net.unit8.bouncr.sign;
 
-public record JwtHeader(String alg, String kid) {
+/** JWT JOSE Header per RFC 7519 §5 / RFC 7515 §4. */
+public record JwtHeader(String typ, String alg, String kid) {
 }

--- a/src/main/java/net/unit8/bouncr/sign/JwtHeader.java
+++ b/src/main/java/net/unit8/bouncr/sign/JwtHeader.java
@@ -1,5 +1,8 @@
 package net.unit8.bouncr.sign;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /** JWT JOSE Header per RFC 7519 §5 / RFC 7515 §4. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record JwtHeader(String typ, String alg, String kid) {
 }

--- a/src/test/java/enkan/security/bouncr/BouncrBackendTest.java
+++ b/src/test/java/enkan/security/bouncr/BouncrBackendTest.java
@@ -63,11 +63,11 @@ public class BouncrBackendTest {
     }
 
     private String signHmac(Map<String, Object> claims, byte[] key) {
-        return jwt.sign(claims, new JwtHeader("HS256", null), key);
+        return jwt.sign(claims, new JwtHeader(null, "HS256", null), key);
     }
 
     private String signRsa(Map<String, Object> claims, PrivateKey key) {
-        return jwt.sign(claims, new JwtHeader("RS256", null), key);
+        return jwt.sign(claims, new JwtHeader(null, "RS256", null), key);
     }
 
     // --- parse() ---

--- a/src/test/java/net/unit8/bouncr/sign/JsonWebTokenTest.java
+++ b/src/test/java/net/unit8/bouncr/sign/JsonWebTokenTest.java
@@ -48,11 +48,11 @@ public class JsonWebTokenTest {
     }
 
     private String sign(Map<String, Object> claims, String alg, byte[] key) {
-        return jwt.sign(claims, new JwtHeader(alg, null), key);
+        return jwt.sign(claims, new JwtHeader(null, alg, null), key);
     }
 
     private String sign(Map<String, Object> claims, String alg, PrivateKey key) {
-        return jwt.sign(claims, new JwtHeader(alg, null), key);
+        return jwt.sign(claims, new JwtHeader(null, alg, null), key);
     }
 
     // --- HMAC algorithms ---
@@ -155,7 +155,7 @@ public class JsonWebTokenTest {
         claim.setSub("kawasima");
         claim.setIss("test-issuer");
 
-        String token = jwt.sign(claim, new JwtHeader("RS256", null), keyPair.getPrivate());
+        String token = jwt.sign(claim, new JwtHeader(null, "RS256", null), keyPair.getPrivate());
         Map<String, Object> result = jwt.unsign(token, keyPair.getPublic(), new TypeReference<Map<String, Object>>() {});
         assertThat(result).containsEntry("sub", "kawasima");
         assertThat(result).containsEntry("iss", "test-issuer");
@@ -167,7 +167,7 @@ public class JsonWebTokenTest {
         JwtClaim claim = new JwtClaim();
         claim.setSub("kawasima");
 
-        String token = jwt.sign(claim, new JwtHeader("HS256", null), key);
+        String token = jwt.sign(claim, new JwtHeader(null, "HS256", null), key);
         Map<String, Object> result = jwt.unsign(token, key, new TypeReference<Map<String, Object>>() {});
         assertThat(result).containsEntry("sub", "kawasima");
     }
@@ -315,7 +315,7 @@ public class JsonWebTokenTest {
     public void signThrowsWhenNotStarted() {
         JsonWebToken unstartedJwt = new JsonWebToken();
         byte[] key = "key".getBytes(StandardCharsets.UTF_8);
-        assertThatThrownBy(() -> unstartedJwt.sign(Map.of("sub", "x"), new JwtHeader("HS256", null), key))
+        assertThatThrownBy(() -> unstartedJwt.sign(Map.of("sub", "x"), new JwtHeader(null, "HS256", null), key))
                 .isInstanceOf(MisconfigurationException.class);
     }
 
@@ -323,7 +323,7 @@ public class JsonWebTokenTest {
 
     @Test
     public void signThrowsWhenKeyIsNull() {
-        assertThatThrownBy(() -> jwt.sign("payload", new JwtHeader("HS256", null), (byte[]) null))
+        assertThatThrownBy(() -> jwt.sign("payload", new JwtHeader(null, "HS256", null), (byte[]) null))
                 .isInstanceOf(MisconfigurationException.class);
     }
 
@@ -332,7 +332,7 @@ public class JsonWebTokenTest {
     @Test
     public void signThrowsWhenAlgIsNone() {
         byte[] key = "key".getBytes(StandardCharsets.UTF_8);
-        assertThatThrownBy(() -> jwt.sign(Map.of("sub", "x"), new JwtHeader("none", null), key))
+        assertThatThrownBy(() -> jwt.sign(Map.of("sub", "x"), new JwtHeader(null, "none", null), key))
                 .isInstanceOf(MisconfigurationException.class);
     }
 }

--- a/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
+++ b/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
@@ -1,5 +1,6 @@
 package net.unit8.bouncr.sign;
 
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -211,6 +212,17 @@ public class JwtClaimSerializationTest {
     public void deserializesAmrAsArray() throws Exception {
         JwtClaim claim = mapper.readValue("{\"amr\":[\"pwd\",\"otp\"]}", JwtClaim.class);
         assertThat(claim.getAmr()).containsExactly("pwd", "otp");
+    }
+
+    @Test
+    public void deserializesAmrAsSingleString() throws Exception {
+        // Production mapper (JsonWebToken) enables ACCEPT_SINGLE_VALUE_AS_ARRAY.
+        // Verify that a bare string value is wrapped into a single-element list.
+        JsonMapper productionMapper = JsonMapper.builder()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                .build();
+        JwtClaim claim = productionMapper.readValue("{\"amr\":\"pwd\"}", JwtClaim.class);
+        assertThat(claim.getAmr()).containsExactly("pwd");
     }
 
     // --- updated_at (OIDC Core §5.1): NumericDate as Long ---

--- a/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
+++ b/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
@@ -169,9 +169,9 @@ public class JwtClaimSerializationTest {
 
     @Test
     public void jwtHeaderEqualsAndHashCode() {
-        JwtHeader h1 = new JwtHeader("RS256", "key-1");
-        JwtHeader h2 = new JwtHeader("RS256", "key-1");
-        JwtHeader h3 = new JwtHeader("HS256", "key-1");
+        JwtHeader h1 = new JwtHeader(null, "RS256", "key-1");
+        JwtHeader h2 = new JwtHeader(null, "RS256", "key-1");
+        JwtHeader h3 = new JwtHeader(null, "HS256", "key-1");
 
         assertThat(h1).isEqualTo(h2);
         assertThat(h1.hashCode()).isEqualTo(h2.hashCode());
@@ -180,8 +180,8 @@ public class JwtClaimSerializationTest {
 
     @Test
     public void jwtHeaderNullFieldsEquality() {
-        JwtHeader h1 = new JwtHeader("RS256", null);
-        JwtHeader h2 = new JwtHeader("RS256", null);
+        JwtHeader h1 = new JwtHeader(null, "RS256", null);
+        JwtHeader h2 = new JwtHeader(null, "RS256", null);
 
         assertThat(h1).isEqualTo(h2);
         assertThat(h1).isNotEqualTo(null);

--- a/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
+++ b/src/test/java/net/unit8/bouncr/sign/JwtClaimSerializationTest.java
@@ -4,6 +4,8 @@ import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JwtClaimSerializationTest {
@@ -163,6 +165,68 @@ public class JwtClaimSerializationTest {
         String json = "{\"sub\":\"kawasima\",\"unknown_future_claim\":\"value\"}";
         JwtClaim claim = mapper.readValue(json, JwtClaim.class);
         assertThat(claim.getSub()).isEqualTo("kawasima");
+    }
+
+    // --- aud (RFC 7519 §4.1.3): single string or array ---
+
+    @Test
+    public void serializesAudAsString() throws Exception {
+        JwtClaim claim = new JwtClaim();
+        claim.setAud("myapp");
+        String json = mapper.writeValueAsString(claim);
+        assertThat(json).contains("\"aud\":\"myapp\"");
+    }
+
+    @Test
+    public void serializesAudAsArray() throws Exception {
+        JwtClaim claim = new JwtClaim();
+        claim.setAud(List.of("app1", "app2"));
+        String json = mapper.writeValueAsString(claim);
+        assertThat(json).contains("\"aud\":[\"app1\",\"app2\"]");
+    }
+
+    @Test
+    public void deserializesAudAsString() throws Exception {
+        JwtClaim claim = mapper.readValue("{\"aud\":\"myapp\"}", JwtClaim.class);
+        assertThat(claim.getAud()).isEqualTo("myapp");
+    }
+
+    @Test
+    public void deserializesAudAsArray() throws Exception {
+        JwtClaim claim = mapper.readValue("{\"aud\":[\"app1\",\"app2\"]}", JwtClaim.class);
+        assertThat(claim.getAud()).isInstanceOf(List.class);
+    }
+
+    // --- amr (OIDC Core §2): array of strings, accepts single string ---
+
+    @Test
+    public void serializesAmrAsArray() throws Exception {
+        JwtClaim claim = new JwtClaim();
+        claim.setAmr(List.of("pwd", "otp"));
+        String json = mapper.writeValueAsString(claim);
+        assertThat(json).contains("\"amr\":[\"pwd\",\"otp\"]");
+    }
+
+    @Test
+    public void deserializesAmrAsArray() throws Exception {
+        JwtClaim claim = mapper.readValue("{\"amr\":[\"pwd\",\"otp\"]}", JwtClaim.class);
+        assertThat(claim.getAmr()).containsExactly("pwd", "otp");
+    }
+
+    // --- updated_at (OIDC Core §5.1): NumericDate as Long ---
+
+    @Test
+    public void serializesUpdatedAtAsNumber() throws Exception {
+        JwtClaim claim = new JwtClaim();
+        claim.setUpdatedAt(1700000000L);
+        String json = mapper.writeValueAsString(claim);
+        assertThat(json).contains("\"updated_at\":1700000000");
+    }
+
+    @Test
+    public void deserializesUpdatedAtAsNumber() throws Exception {
+        JwtClaim claim = mapper.readValue("{\"updated_at\":1700000000}", JwtClaim.class);
+        assertThat(claim.getUpdatedAt()).isEqualTo(1700000000L);
     }
 
     // --- JwtHeader equals/hashCode ---


### PR DESCRIPTION
## Summary
- `JwtClaim.aud`: `String` → `Object` — supports both `"aud":"app"` and `"aud":["app1","app2"]` (RFC 7519 §4.1.3)
- `JwtClaim.amr`: `String` → `List<String>` — per OIDC Core §2
- `JwtClaim.updatedAt`: `LocalDateTime` → `Long` — NumericDate per RFC 7519 §2
- `JwtHeader`: added `typ` field (RFC 7519 §5.1); constructor is now `JwtHeader(typ, alg, kid)`

## Test plan
- [x] All 78 existing tests pass (constructor calls updated throughout)

closes #9
closes #11
closes #13
closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)